### PR TITLE
added multi output to the target head

### DIFF
--- a/cfgs/train.yaml
+++ b/cfgs/train.yaml
@@ -29,6 +29,7 @@ dataset:
   discrete_index: null  # Explicitly setting a default as nul
   loss_latent_weight: 1
   loss_data_weight: 1
+  dim_y: 1
 
 ##### W&B config #####
 wandb:

--- a/src/model/target_head.py
+++ b/src/model/target_head.py
@@ -15,9 +15,10 @@ class GaussianHead(nn.Module):
         dim_feedforward: int,
         name: Optional[str] = None,
         bound_std: bool = True,
-        std_min: float = 1e-3,
-        **kwargs: Any,
+        std_min: float = 0.001, 
+        **kwargs: Any
     ) -> None:
+        
         super().__init__()
         self.bound_std = bound_std
         self.std_min = std_min
@@ -28,19 +29,10 @@ class GaussianHead(nn.Module):
             nn.Linear(dim_feedforward, dim_y * 2),
         )
 
-    def forward(
-        self,
-        batch: Any,
-        z_target: torch.Tensor,
-        reduce_ll: bool = True,
-        predict: bool = False,
-        num_samples: int = 0,
-    ) -> AttrDict:
+    def forward(self, batch: Any, z_target: torch.Tensor, reduce_ll: bool = True, predict: bool = False, num_samples: int = 0) -> AttrDict:
         out = self.predictor(z_target)
         mean, raw_std = torch.chunk(out, 2, dim=-1)
-        std = (
-            self.std_min + F.softplus(raw_std) if self.bound_std else torch.exp(raw_std)
-        )
+        std = self.std_min + F.softplus(raw_std) if self.bound_std else torch.exp(raw_std)
 
         pred_tar = Normal(mean, std)
         outs = AttrDict()
@@ -49,11 +41,7 @@ class GaussianHead(nn.Module):
             outs.scale = std
             outs.samples = pred_tar.sample((num_samples,)).movedim(0, 2)
         else:
-            outs.tar_ll = (
-                pred_tar.log_prob(batch.yt).sum(-1).mean()
-                if reduce_ll
-                else pred_tar.log_prob(batch.yt).sum(-1)
-            )
+            outs.tar_ll = pred_tar.log_prob(batch.yt).mean() if reduce_ll else pred_tar.log_prob(batch.yt)
             outs.loss = -(outs.tar_ll)
         return outs
 
@@ -72,8 +60,9 @@ class MixtureGaussian(nn.Module):
         loss_latent_weight: float = 1.0,
         loss_data_weight: float = 1.0,
         discrete_index: Optional[List[int]] = None,
-        bias_init: bool = True,
+        bias_init: bool = False,
     ) -> None:
+        
         super().__init__()
         self.name = name
         self.d_model = d_model
@@ -86,12 +75,10 @@ class MixtureGaussian(nn.Module):
             self.class_head = nn.Sequential(
                 nn.Linear(self.d_model, self.dim_feedforward),
                 nn.ReLU(),
-                nn.Linear(self.dim_feedforward, len(discrete_index) * self.dim_y),
+                nn.Linear(self.dim_feedforward, len(discrete_index)),
             )
 
-        self.heads = initialize_head(
-            d_model, dim_feedforward, dim_y, single_head, num_components
-        )
+        self.heads = initialize_head(d_model, dim_feedforward, dim_y, single_head, num_components)
         self.num_components = num_components
 
         if trange is None:
@@ -117,14 +104,8 @@ class MixtureGaussian(nn.Module):
         self.loss_data_weight = loss_data_weight
         self.loss_latent_weight = loss_latent_weight
 
-    def forward(
-        self,
-        batch: AttrDict,
-        z_target: torch.Tensor,
-        reduce_ll: bool = True,
-        predict: bool = False,
-        num_samples: int = 1000,
-    ) -> AttrDict:
+    def forward(self, batch: AttrDict, z_target: torch.Tensor, *, reduce_ll: bool = True, predict: bool = False,
+                num_samples: int = 1000) -> AttrDict:
         # Iterate over each head to get their outputs
         if self.single_head:
             output = self.heads(z_target)
@@ -134,18 +115,38 @@ class MixtureGaussian(nn.Module):
             else:
                 raw_mean, raw_std, raw_weights = torch.chunk(output, 3, dim=-1)
         else:
-            outputs = [
-                head(z_target) for head in self.heads
-            ]  # list of [B, T, dim_y * 3] * components
+            outputs = [head(z_target) for head in self.heads]  # list of [B, T, dim_y * 3] * components
             raw_mean, raw_std, raw_weights = self._map_raw_output(outputs)
 
         # Adding bias terms
         mean, std, weights = self.add_bias(raw_mean, raw_std, raw_weights)
-        tar_ll = self.compute_ll(batch.yt, mean, std, weights)  # log-likelihoods [B, T]
-        log_probs = tar_ll  # save it for calculating log probs in SBI
+        
+        # Getting dimensions
+        B, T, C = mean.shape
+        
+        # Reshape parameters for each dimension
+        # Instead of assuming 3 dimensions (RGB), make it work for any dim_y
+        mean_reshaped = mean.reshape(B, T, self.num_components, self.dim_y)
+        std_reshaped = std.reshape(B, T, self.num_components, self.dim_y)
+        weights_reshaped = weights.reshape(B, T, self.num_components, self.dim_y)
+        weights_reshaped = F.softmax(weights_reshaped, dim=2)  # Softmax over components dimension
+        
+        # Compute log-likelihood for each dimension
+        tar_ll_dims = []
+        for dim in range(self.dim_y):
+            dim_ll = self.compute_ll(
+                batch.yt[:,:,dim:dim+1],
+                mean_reshaped[:,:,:,dim],
+                std_reshaped[:,:,:,dim],
+                weights_reshaped[:,:,:,dim]
+            )
+            tar_ll_dims.append(dim_ll)
+        
+        # Average log-likelihood across all dimensions
+        tar_ll = sum(tar_ll_dims) / self.dim_y
 
         if self.discrete_index:
-            output_d = self.class_head(z_target)
+            output_d = self.class_head(z_target) # [B, T, num_classes]
             continuous_mask, discrete_mask = self.build_mask(
                 batch
             )  # Mask [batch, num_target]
@@ -175,12 +176,10 @@ class MixtureGaussian(nn.Module):
         outs = AttrDict()
 
         if predict:
-            samples, median, q1, q3 = self.predict_out(
-                mean, std, weights, batch, num_samples
-            )
+            samples, median, q1, q3 = self.predict_out(mean_reshaped, std_reshaped, weights_reshaped, batch, num_samples)
             outs.samples = samples
             # [BxT, num_samples] -> [B, T, 1]
-            outs.mean = samples.mean(dim=2, keepdim=True)  # sample mean
+            outs.mean = samples.mean(dim=2, keepdim=False)  # sample mean
             outs.median = median
             outs.q1 = q1
             outs.q3 = q3
@@ -191,50 +190,37 @@ class MixtureGaussian(nn.Module):
             outs.mixture_weights = weights
 
             if self.discrete_index:
+                outs.output_permuted = output_permuted
                 outs.logits = filtered_output_d
-                outs.class_pred = torch.argmax(
-                    filtered_output_d
-                    * (discrete_mask.unsqueeze(-1).expand(filtered_output_d.shape)),
-                    dim=-1,
-                )
+                outs.discrete_labels = discrete_labels
                 outs.discrete_mask = discrete_mask
                 outs.continuous_mask = continuous_mask
-
-            outs.losses = log_probs
 
         outs.loss = loss  # weighted negative log-likelihood
         outs.tar_ll = tar_ll  # log-likelihood
         return outs
 
-    def add_bias(
-        self, raw_mean: torch.Tensor, raw_std: torch.Tensor, raw_weights: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def add_bias(self, raw_mean: torch.Tensor, raw_std: torch.Tensor, raw_weights: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if self.bias_init:
             mean = raw_mean + self.mean_global_bias
             std = F.softplus(raw_std + self.std_global_bias) + self.std_min
-            # std = torch.maximum(std, torch.tensor(0.1)) # needed for image
             weights = F.softmax(raw_weights + self.weights_global_bias, dim=-1)
         else:
             mean = raw_mean
             std = F.softplus(raw_std) + self.std_min
             weights = F.softmax(raw_weights, dim=-1)
-        return mean, std, weights
+        return mean, std, raw_weights
 
     @staticmethod
-    def compute_ll(
-        value: torch.Tensor,
-        means: torch.Tensor,
-        stds: torch.Tensor,
-        weights: torch.Tensor,
-    ) -> torch.Tensor:
+    def compute_ll(value: torch.Tensor, means: torch.Tensor, stds: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
         """
         Computes log-likelihood loss for a Gaussian mixture model.
 
         Parameters:
         - value (Tensor): Observed values. Shape: [B, Target, 1]
         - means (Tensor): Gaussian means. Shape: [B, Target, num_components]
-        - stds (Tensor): Gaussian standard deviations. Shape: [Target, num_components]
-        - weights (Tensor): Gaussian mixing weights. Shape: [Target, num_components]
+        - stds (Tensor): Gaussian standard deviations. Shape: [B, Target, num_components]
+        - weights (Tensor): Gaussian mixing weights. Shape: [B, Target, num_components]
 
         Returns:
         - Tensor: Computed loss. Shape: [B, Target]
@@ -243,51 +229,63 @@ class MixtureGaussian(nn.Module):
         log_probs = components.log_prob(value)
         weighted_log_probs = log_probs + torch.log(weights)
         return torch.logsumexp(weighted_log_probs, dim=-1)
-
-    def predict_out(
-        self,
-        mean: torch.Tensor,
-        std: torch.Tensor,
-        weights: torch.Tensor,
-        batch: Any,
-        num_samples: int = 1000,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        samples_flattened = sample(
-            mean.view(-1, self.num_components),
-            std.view(-1, self.num_components),
-            weights.view(-1, self.num_components),
-            num_sample=num_samples,
-        )  # [BxT, num_samples]
-
-        samples = samples_flattened.view(
-            batch.yt.shape[0], batch.yt.shape[1], num_samples
-        )  # [BxT, num_samples] -> [B, T, num_samples]
-
-        # Calculate the quantiles
-        q1 = torch.quantile(samples, 0.25, dim=-1)
-        median = torch.quantile(samples, 0.50, dim=-1)
-        q3 = torch.quantile(samples, 0.75, dim=-1)
-
-        return samples, median, q1, q3
-
-    @staticmethod
-    def _map_raw_output(
-        outputs: List[torch.Tensor],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        concatenated = (
-            torch.stack(outputs).movedim(0, -1).flatten(-2, -1)
-        )  # [B, T, dim_y * 3 * components]
-        raw_mean, raw_std, raw_weights = torch.chunk(
-            concatenated, 3, dim=-1
-        )  # 3 x [B, T, components]
-        return raw_mean, raw_std, raw_weights
-
-    @staticmethod
-    def _discrete(
-        batch: Any, output_d: torch.Tensor, discrete_mask: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    
+    def predict_out(self, mean: torch.Tensor, std: torch.Tensor, weights: torch.Tensor, batch: Any, num_samples: int = 1000) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
-        Applies a discrete mask to the model's output tensors and modifies their dimensions to prepare
+        Generate predictions for each dimension of the output.
+        
+        Parameters:
+        - mean: Shape [B, T, num_components, dim_y]
+        - std: Shape [B, T, num_components, dim_y]
+        - weights: Shape [B, T, num_components, dim_y]
+        - batch: Batch data
+        - num_samples: Number of samples to generate
+        
+        Returns:
+        - samples: Predicted samples
+        - median: Median values
+        - q1: First quartile values
+        - q3: Third quartile values
+        """
+        # Initialize tensor to store samples for each dimension
+        all_samples = []
+        
+        # Generate samples for each dimension
+        for dim in range(self.dim_y):
+            samples_flattened = sample(
+                mean[:,:,:,dim].view(-1, self.num_components),
+                std[:,:,:,dim].view(-1, self.num_components),
+                weights[:,:,:,dim].view(-1, self.num_components),
+                num_sample=num_samples,
+            )
+            
+            # Reshape the samples
+            samples_dim = samples_flattened.view(
+                batch.yt.shape[0], batch.yt.shape[1], num_samples
+            )  # [BxT, num_samples] -> [B, T, num_samples]
+            
+            all_samples.append(samples_dim.unsqueeze(-1))
+        
+        # Concatenate samples from all dimensions
+        samples = torch.cat(all_samples, dim=-1)  # [B, T, num_samples, dim_y]
+        
+        # Calculate quantiles
+        q1 = torch.quantile(samples, 0.25, dim=2)
+        median = torch.quantile(samples, 0.50, dim=2)
+        q3 = torch.quantile(samples, 0.75, dim=2)
+        
+        return samples, median, q1, q3
+    
+    @staticmethod
+    def _map_raw_output(outputs: List[torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        concatenated = torch.stack(outputs).movedim(0, -1).flatten(-2, -1) # [B, T, dim_y * 3 * components]
+        raw_mean, raw_std, raw_weights = torch.chunk(concatenated, 3, dim=-1) # 3 x [B, T, components]
+        return raw_mean, raw_std, raw_weights
+    
+    @staticmethod
+    def _discrete(batch: Any, output_d: torch.Tensor, discrete_mask: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """  
+        Applies a discrete mask to the model's output tensors and modifies their dimensions to prepare 
         for cross-entropy loss computation.
         """
         filtered_output_d = output_d * discrete_mask.unsqueeze(-1).expand(
@@ -301,8 +299,11 @@ class MixtureGaussian(nn.Module):
             0, 2, 1
         )  # [B, num_classes, T] for CrossEntropyLoss
 
-        return output_permuted, discrete_labels.squeeze(-1), filtered_output_d
-
+        # Get the last dimension for discrete labels - update this for different dimensions
+        # Use a different approach if dim_y is variable
+        last_dim_idx = -1
+        return output_permuted, discrete_labels[:,:,last_dim_idx], filtered_output_d
+    
     def build_mask(self, batch: AttrDict) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Generates binary masks for separating target data into discrete and continuous components.
@@ -317,28 +318,21 @@ class MixtureGaussian(nn.Module):
         Note:
         Assumes `batch.yt` contains values comparable to integers for discreteness detection.
         """
-
         device = "cuda" if torch.cuda.is_available() else "cpu"
         # List of discrete values
         discrete_values = torch.tensor(self.discrete_index, device=device)
 
-        # Create the mask
-        mask_discrete = torch.isin(batch.yt, torch.tensor(discrete_values))
+        # For discrete labels, we need to decide which dimension to use
+        # Here we assume the last dimension contains discrete values
+        # This could be parameterized in the class init if needed
+        mask_discrete = torch.isin(batch.yt[:,:,-1:], torch.tensor(discrete_values))
         continuous_mask = ~mask_discrete
 
-        # continuous_mask = continuous_mask.expand(batch.xte.shape[0], batch.xte.shape[1], components)
         return continuous_mask.squeeze(-1), mask_discrete.squeeze(-1)
 
-
 def sample(
-    means: torch.Tensor,
-    stds: torch.Tensor,
-    weights: torch.Tensor,
-    num_sample: int = 1000,
-) -> torch.Tensor:
-    # TODO: swap out with pytorch inbuilt torch.distributions.mixture_same_family.MixtureSameFamily
+    means: torch.Tensor, stds: torch.Tensor, weights: torch.Tensor, num_sample: int = 1000) -> torch.Tensor:
     # Sample component indices for each batch
-
     mixture_dists = Categorical(weights, validate_args=False)
     component_indices = mixture_dists.sample((num_sample,))  # Shape [num_samples, TxB]
 
@@ -362,9 +356,5 @@ def sample(
 
     return samples.t()
 
-
 def inverse_softplus(y: torch.Tensor) -> torch.Tensor:
     return torch.log(torch.special.expm1(y))
-
-
-# if __name__ == "__main__":


### PR DESCRIPTION
# What is this about?
The current code base doesn't allow for us to specify multi-output y. For CelebA, for example, you have RGB output channels. This will be the first step to allow CelebA to be merged.

# What’s Changing?
The code now looks slightly different in how it initialises and computes the loss; however, this should remain the same for single output.

# What needs to be checked?
Could you check that the output is now consistent with your experiments? @satrialoka 